### PR TITLE
forge installer用のJREの存在をチェック・ダウンロードする処理を修正しました

### DIFF
--- a/launch.bat
+++ b/launch.bat
@@ -20,24 +20,45 @@ echo "|_ _| \| / __|_   _/_\ | |   | |  | __| _ \"
 echo " | || .` \__ \ | |/ _ \| |__ | |__| _||   /"
 echo "|___|_|\_|___/ |_/_/ \_\____||____|___|_|_\"
 
-if exist %APPDATA%\.minecraft\launcher_profiles.json goto install
+if exist %APPDATA%\.minecraft\launcher_profiles.json goto runJavaCheck
 echo hmm... couldn't find minecraft. then, perform download only.
 timeout 5 >nul
 call :download
 goto finish
 
-:installForge
-echo java check
-call java --version >nul
-if not %errorlevel% == 0(
-    aria2c https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jdk_x64_windows_hotspot_17.0.7_7.msi
-    msiexec /i .\OpenJDK17U-jdk_x64_windows_hotspot_17.0.7_7.msi ADDLOCAL=FeatureMain,FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome INSTALLDIR="c:\Program Files\Temurin\" /quiet
-    del .\OpenJDK17U-jdk_x64_windows_hotspot_17.0.7_7.msi
+:javaCheck
+call %JAVA_EXE% -version >NUL 2>NUL
+if not errorlevel 1 (
+    echo found java at %JAVA_EXE%
+    goto install
 )
+exit /b
+
+:runJavaCheck
+echo java check
+
+timeout /t 5
+
+set JAVA_EXE="%ProgramFiles%..\Program Files (x86)\Minecraft Launcher\runtime\java-runtime-gamma\windows-x64\java-runtime-gamma\bin\java.exe"
+call :javaCheck
+
+set JAVA_EXE="%LocalAppData%\Packages\Microsoft.4297127D64EC6_8wekyb3d8bbwe\LocalCache\Local\runtime\java-runtime-gamma\windows-x64\java-runtime-gamma\bin\java.exe"
+call :javaCheck
+
+set JAVA_EXE="%~dp0OpenJDK17U-jre_x64_windows_hotspot_17.0.7_7\jdk-17.0.7+7-jre\bin\java.exe"
+if not exist %JAVA_EXE% (
+    call "%~dp0aria2c.exe" "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7+7/OpenJDK17U-jre_x64_windows_hotspot_17.0.7_7.zip"
+    call powershell -command "Expand-Archive -Force OpenJDK17U-jre_x64_windows_hotspot_17.0.7_7.zip"
+    del "OpenJDK17U-jre_x64_windows_hotspot_17.0.7_7.zip"
+)
+call :installForge
+goto :install
+
+:installForge
 echo trying install Forge...
-aria2c https://maven.minecraftforge.net/net/minecraftforge/forge/1.19.2-43.2.14/forge-1.19.2-43.2.14-installer.jar
-java -jar .\forge-1.19.2-43.2.14-installer.jar
-del .\forge-1.19.2-43.2.14-installer.jar
+call "%~dp0aria2c.exe" https://maven.minecraftforge.net/net/minecraftforge/forge/1.19.2-43.2.14/forge-1.19.2-43.2.14-installer.jar
+call %JAVA_EXE% -jar "%~dp0forge-1.19.2-43.2.14-installer.jar"
+del "%~dp0forge-1.19.2-43.2.14-installer.jar"
 exit /b
 
 :install


### PR DESCRIPTION
- JRE が存在しない場合、Minecraft Java Edition のインストールディレクトリから検索するようにしました
- Minecraft もインストールされていない場合、JRE をダウンロードするようにしました
- ダウンロードする JRE を Installer 版から Portable 版に変更しました